### PR TITLE
feat: add Proxmox network provisioning commands

### DIFF
--- a/defaults/autocomplete.yml
+++ b/defaults/autocomplete.yml
@@ -98,6 +98,29 @@ autocomplete:
           subcommand_description: Run deploy-role on failed machines based on playbook.retry file
           subcommand_to_execute: ansible-playbook $PWD/playbook.yml -e @~/.vault/vlt -e=deploy_mode=deploy -e role_only=true -l @playbook.retry "$@"
 
+    - command: network
+      description: Commands for provisioning environment networks
+      hosts_as_arguments: false
+      subcommands:
+        - subcommand_name: plan
+          subcommand_description: Shows Proxmox SDN zones, VNets and subnets that would be managed from Providentia
+          subcommand_to_execute:
+            ANSIBLE_STRATEGY=linear ANSIBLE_SERIAL=100% ansible-playbook $PWD/playbook.yml -e @~/.vault/vlt
+            -e=deploy_mode=deploy -e pre_role=nova.core.proxmox_networks
+            -e proxmox_networks_mode=plan -e deploy_vars_get_vault_token=false "$@"
+        - subcommand_name: deploy
+          subcommand_description: Creates missing Proxmox SDN zones, VNets and subnets from Providentia
+          subcommand_to_execute:
+            ANSIBLE_STRATEGY=linear ANSIBLE_SERIAL=100% ansible-playbook $PWD/playbook.yml -e @~/.vault/vlt
+            -e=deploy_mode=deploy -e pre_role=nova.core.proxmox_networks
+            -e proxmox_networks_mode=deploy -e deploy_vars_get_vault_token=false "$@"
+        - subcommand_name: sync
+          subcommand_description: Creates and updates Proxmox SDN zones, VNets and subnets from Providentia
+          subcommand_to_execute:
+            ANSIBLE_STRATEGY=linear ANSIBLE_SERIAL=100% ansible-playbook $PWD/playbook.yml -e @~/.vault/vlt
+            -e=deploy_mode=deploy -e pre_role=nova.core.proxmox_networks
+            -e proxmox_networks_mode=sync -e deploy_vars_get_vault_token=false "$@"
+
     - command: vm
       description: Commands for configuring hosts on an hypervisor level
       hosts_as_arguments: true

--- a/docs/20-how-to-use.md
+++ b/docs/20-how-to-use.md
@@ -332,6 +332,35 @@ _Example usage:_
 ctp host deploy-network <inventory_hostname>
 ```
 
+### ctp network plan
+
+Shows the Proxmox SDN zones, VNets and subnets that Catapult would manage from
+the Providentia network definitions. This does not change Proxmox. The command
+runs once with Ansible's linear strategy regardless of the normal deployment
+strategy.
+
+```zsh
+ctp network plan
+```
+
+### ctp network deploy
+
+Creates missing Proxmox SDN zones, VNets and subnets from Providentia. Existing
+VNets are used as-is and are not updated by this command.
+
+```zsh
+ctp network deploy
+```
+
+### ctp network sync
+
+Creates missing Proxmox SDN resources and updates existing zones, VNets and
+subnets to match Providentia.
+
+```zsh
+ctp network sync
+```
+
 ### ctp host deploy-fresh
 
 Runs deploy as if the machine does not exist. This can be useful when deploy has failed before configuring accounts. Use this command to deploy the machine again as if it didn't exist and thus use the default values for the accounts.

--- a/version.yml
+++ b/version.yml
@@ -1,1 +1,1 @@
-version: 14.0.4
+version: 14.0.5


### PR DESCRIPTION
## Summary

Adds top-level Catapult commands for provisioning Proxmox SDN networks from Providentia definitions.

## Details

- Adds `ctp network plan`.
- Adds `ctp network deploy`.
- Adds `ctp network sync`.
- Runs `nova.core.proxmox_networks` as a pre-role against the selected project inventory.
- Forces Ansible's linear strategy and full serial for these commands so SDN reconciliation runs once predictably.

This depends on the companion `nova.core` feature that adds the `nova.core.proxmox_networks` role.

## Testing

- YAML parse check for `defaults/autocomplete.yml`
